### PR TITLE
feat(install): update GPG configuration and use Java21

### DIFF
--- a/apim/4.x/redhat/install_redhat.sh
+++ b/apim/4.x/redhat/install_redhat.sh
@@ -82,9 +82,10 @@ install_graviteeio() {
     echo "[graviteeio]
 name=graviteeio
 baseurl=https://packagecloud.io/graviteeio/rpms/el/7/\$basearch
-gpgcheck=0
+gpgcheck=1
+repo_gpgcheck=1
 enabled=1
-gpgkey=https://packagecloud.io/graviteeio/rpms/gpgkey
+gpgkey=https://packagecloud.io/graviteeio/rpms/gpgkey,https://packagecloud.io/graviteeio/rpms/gpgkey/graviteeio-rpms-319791EF7A93C060.pub.gpg
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
 metadata_expire=300" | sudo tee /etc/yum.repos.d/graviteeio.repo > /dev/null
@@ -131,7 +132,7 @@ metadata_expire=300" | sudo tee /etc/yum.repos.d/graviteeio.repo > /dev/null
 }
 
 install_openjdk() {
-    sudo yum install -y java-17-openjdk-devel
+    sudo yum install -y java-21-openjdk-devel
 }
 
 install_tools() {

--- a/apim/4.x/sles/install_sles.sh
+++ b/apim/4.x/sles/install_sles.sh
@@ -41,13 +41,15 @@ install_graviteeio() {
     echo "[graviteeio]
 name=graviteeio
 baseurl=https://packagecloud.io/graviteeio/rpms/el/7/\$basearch
-gpgcheck=0
+gpgcheck=1
+repo_gpgcheck=1
 enabled=1
-gpgkey=https://packagecloud.io/graviteeio/rpms/gpgkey
+gpgkey=https://packagecloud.io/graviteeio/rpms/gpgkey,https://packagecloud.io/graviteeio/rpms/gpgkey/graviteeio-rpms-319791EF7A93C060.pub.gpg
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
 metadata_expire=300
 type=rpm-md" | sudo tee /etc/zypp/repos.d/graviteeio.repo > /dev/null
+    sudo zypper --gpg-auto-import-keys refresh graviteeio
     sudo zypper -n install graviteeio-apim-4x
     sudo systemctl daemon-reload
     sudo systemctl start graviteeio-apim-gateway graviteeio-apim-rest-api
@@ -67,7 +69,7 @@ install_openjdk() {
     sudo zypper refresh
   fi
 
-  sudo zypper -n install java-17-openjdk
+  sudo zypper -n install java-21-openjdk
 }
 
 main() {


### PR DESCRIPTION
* We now sign our RPM with our GPG key so we can enable the gpgcheck on
  RPM repository configuration
* Also since APIM/AM 4.7 we use Java 21 so we install that JDK version
  now.

TT-7286
