### PR TITLE
chore: add @gravitee-io/tech-lead to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default
-*       @gravitee-io/archi
+*       @gravitee-io/archi @gravitee-io/tech-lead
 
 /apim/  @gravitee-io/apim
 /am/    @gravitee-io/am


### PR DESCRIPTION
## Summary
- Add `@gravitee-io/tech-lead` team as code owners alongside `@gravitee-io/archi` for the entire repository

## Changes
The CODEOWNERS file is updated to include `@gravitee-io/tech-lead` on the `*` pattern, ensuring that members of the tech-lead team are automatically requested for review on all pull requests.